### PR TITLE
WDP190601-37

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -2,6 +2,20 @@
   background-color: #ffffff;
   border: 1px solid #e1e1e1;
   margin-bottom: 2rem;
+  &:hover {
+    .photo {
+      .buttons {
+        display: flex;
+      }
+    }
+    .actions {
+      .price {
+        .btn-main-small {
+          background-color: $primary;
+        }
+      }
+    }
+  }
 
   .photo {
     position: relative;
@@ -27,7 +41,7 @@
     }
 
     .buttons {
-      display: flex;
+      display: none;
       justify-content: space-between;
     }
   }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -5,7 +5,7 @@
   &:hover {
     .photo {
       .buttons {
-        display: flex;
+        visibility: visible;
       }
     }
     .actions {
@@ -41,7 +41,8 @@
     }
 
     .buttons {
-      display: none;
+      display: flex;
+      visibility: hidden;
       justify-content: space-between;
     }
   }


### PR DESCRIPTION
Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 

Na div z klasą buttons gdzie znajdują się btn Quick View i Add to cart ustawiłem display: none, dotychczasowy display: flex jest ustawiony na hoverze na całego boxa, plus zmiana tła ceny na $primary.

**Jiry link:** https://projects.kodilla.com/browse/WDP190601-37