### PR TITLE
WDP190601-46

### DIFF
--- a/src/partials/30_section-features.html
+++ b/src/partials/30_section-features.html
@@ -1,7 +1,7 @@
 <div class="section--features">
   <div class="container">
     <div class="row">
-      <div class="col">
+      <div class="col-lg-3 col-6">
         <div class="feature-box active">
           <div class="icon"><i class="fas fa-truck"></i></div>
           <div class="content">
@@ -10,7 +10,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-headphones"></i></div>
           <div class="content">
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-reply-all"></i></div>
           <div class="content">
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-lg-3 col-6">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-bullhorn"></i></div>
           <div class="content">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -2,6 +2,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  height: 150px;
 
   .icon {
     transform: translateY(-50%);


### PR DESCRIPTION
**Opis problemu:** Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy kart korzyści ("Free shipping", etc.).

Klient chce w trybach tablet i mobile mieć je w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością. 

**Rozwiazanie:** Dodałem dwie klasy col-6 na małe ekrany i col-lg-3 na wieksze. Ustawiłem sztywną wysokość, ponieważ jeden z boxów miał tendencje do zapadania się w niektórych rozdzielczościach.

**Jiry link:** https://projects.kodilla.com/browse/WDP190601-46