### PR TITLE
WDP190601-47

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -5,11 +5,11 @@
         <div class="col-auto heading"><h3>New furniture</h3></div>
         <div class="col-auto menu">
           <ul>
-            <li><a href="#" class="active">Bed</a></li>
-            <li><a href="#">Chair</a></li>
-            <li><a href="#">Sofa</a></li>
-            <li><a href="#">Table</a></li>
-            <li><a href="#">Dining</a></li>
+            <li><a href="#" class="active" id="type-of-furniture">Bed</a></li>
+            <li><a href="#" id="type-of-furniture">Chair</a></li>
+            <li><a href="#" id="type-of-furniture">Sofa</a></li>
+            <li><a href="#" id="type-of-furniture">Table</a></li>
+            <li><a href="#" id="type-of-furniture">Dining</a></li>
           </ul>
         </div>
         <div class="col-auto dots">

--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -3,7 +3,7 @@
     <div class="panel-bar">
       <div class="row no-gutters align-items-end">
         <div class="col-auto heading"><h3>New furniture</h3></div>
-        <div class="col menu">
+        <div class="col-auto menu">
           <ul>
             <li><a href="#" class="active">Bed</a></li>
             <li><a href="#">Chair</a></li>
@@ -22,10 +22,10 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_001.jpg" alt="bed-001">
+            <img src="/images/bed/bed_001.jpg" alt="bed-001" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -52,10 +52,10 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_002.jpg" alt="bed-002">
+            <img src="/images/bed/bed_002.jpg" alt="bed-002" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -75,16 +75,18 @@
           <div class="actions">
             <div class="outlines">
               <button class="btn-outline active"><i class="far fa-heart"></i></button>
-              <button class="btn-outline active"><i class="fas fa-exchange-alt"></i></button>
+              <button class="btn-outline active">
+                <i class="fas fa-exchange-alt"></i>
+              </button>
             </div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_003.jpg" alt="bed-003">
+            <img src="/images/bed/bed_003.jpg" alt="bed-003" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -104,17 +106,19 @@
           <div class="actions">
             <div class="outlines">
               <button class="btn-outline"><i class="far fa-heart"></i></button>
-              <button class="btn-outline active"><i class="fas fa-exchange-alt"></i></button>
+              <button class="btn-outline active">
+                <i class="fas fa-exchange-alt"></i>
+              </button>
             </div>
             <div class="old-price">$ 15.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_004.jpg" alt="bed-004">
+            <img src="/images/bed/bed_004.jpg" alt="bed-004" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -140,10 +144,10 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_005.jpg" alt="bed-005">
+            <img src="/images/bed/bed_005.jpg" alt="bed-005" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -170,10 +174,10 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_006.jpg" alt="bed-006">
+            <img src="/images/bed/bed_006.jpg" alt="bed-006" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -199,10 +203,10 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_007.jpg" alt="bed-007">
+            <img src="/images/bed/bed_007.jpg" alt="bed-007" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
@@ -228,10 +232,10 @@
           </div>
         </div>
       </div>
-      <div class="col-3">
+      <div class="col-12 col-sm-6 col-md-4 col-lg-3">
         <div class="product-box">
           <div class="photo">
-            <img src="/images/bed/bed_008.jpg" alt="bed-008">
+            <img src="/images/bed/bed_008.jpg" alt="bed-008" />
             <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -91,3 +91,9 @@
     }
   }
 }
+
+@media (max-width: 400px) {
+  #type-of-furniture {
+    font-size: 15px;
+  }
+}

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -30,7 +30,7 @@
     align-items: flex-end;
     z-index: 1;
 
-    >img {
+    > img {
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
**Problem:**
Ten task dotyczy sekcji "New furniture". 
Klient chciałby na tabletach mieć po 2-3 elementy w rzędzie, a na mobilkach 1-2 w rzędzie. Są zakresy, bo trzeba będzie samodzielnie zdecydować co wygląda ok - np. na tabletach landscape (np. szer. 1024px) mogą być 3, a na portrait (np. szer. 768px) by były 2. Podobnie na mobilkach, na takich koło 568px by były 2, a na mniejszych 1 w rzędzie. 
Docelowo to będzie slider, więc będzie widoczny tylko 1 wiersz, ale Klient powiedział że na razie może się wyświetlać więcej wierszy, więc tym się nie przejmujemy. 

**Rozwiązanie:**
Dodanie responsywnych, kolumnowych klas z bootstrapa. Kategorie u góry (bed, chair, sofa etc.), lekko się wywijały przy mniejszych ekranach więc ustawiłem im klasę .col-auto. Efekt tego pozostawiam do oceny - jest lepiej, ale pewnie mogłoby być **jeszcze** lepiej. ;)

Link do [Jira](https://projects.kodilla.com/browse/WDP190601-47)