### PR TITLE
WDP190601-69

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -3,7 +3,7 @@
     <div class="panel-bar">
       <div class="row no-gutters align-items-end">
         <div class="col-auto heading"><h3>New furniture</h3></div>
-        <div class="col-auto menu">
+        <div class="col menu">
           <ul>
             <li><a href="#" class="active" id="type-of-furniture">Bed</a></li>
             <li><a href="#" id="type-of-furniture">Chair</a></li>
@@ -37,8 +37,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -67,8 +70,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -98,8 +104,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star active" data-index="0"></div>  <div class="star active" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star active" data-index="0"></div>
+              <div class="star active" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -130,8 +139,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -159,8 +171,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -189,8 +204,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -218,8 +236,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>
@@ -247,8 +268,11 @@
           <div class="content">
             <h5>Aenean Ru Bristique</h5>
             <div class="stars-container">
-              <div class="star full" data-index="0"></div>  <div class="star full" data-index="1"></div>
-              <div class="star" data-index="2"></div> <div class="star" data-index="3"></div> <div class="star" data-index="4"></div>
+              <div class="star full" data-index="0"></div>
+              <div class="star full" data-index="1"></div>
+              <div class="star" data-index="2"></div>
+              <div class="star" data-index="3"></div>
+              <div class="star" data-index="4"></div>
             </div>
           </div>
           <div class="line"></div>

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -92,6 +92,22 @@
   }
 }
 
+@media (max-width: 767px) {
+  .section--products {
+    .container {
+      .panel-bar {
+        .no-gutters {
+          > .menu {
+            flex: 0 0 auto;
+            width: auto;
+            max-width: none;
+          }
+        }
+      }
+    }
+  }
+}
+
 @media (max-width: 400px) {
   #type-of-furniture {
     font-size: 15px;


### PR DESCRIPTION
OPIS PROBLEMU:

Podczas mergowania na mastera coś się wysypało i belka odpowiedzialna panel bar w sekcji New Furniture nie wyświetla się poprawnie. Powinna wyświetlać się na całą szerokość.

OPIS PROBLEMU: 
Zmieniłem klasę w menu w sekcji new furniture z **col-auto** na **col**. aby też zachowało swoje właściwości RWD to przypisałem w media queries że przy szerokościach <767px menu zachowuje się jakby miało właśnie col-auto. Nie dodawałem jednak dodatkowego pustego diva o klasie col, ponieważ wtedy karty (chair, table, bed itd.) były za bardzo w prawo a nie na środku.