### PR TITLE
WDP190601-58

### DIFF
--- a/src/partials/40_section-deals.html
+++ b/src/partials/40_section-deals.html
@@ -1,7 +1,7 @@
 <div class="section-deals">
   <div class="container">
     <div class="row">
-      <div class="col-lg-6">
+      <div class="col-12 col-lg-6">
         <div class="deals-box-left">
           <img class="deals-photo left" src="/images/bed/bed_008.jpg" alt="bed-008" />
           <div class="deals-discount">
@@ -11,9 +11,9 @@
           </div>
         </div>
       </div>
-      <div class="col-lg-6">
-        <div class="row">
-          <div class="col-lg-12">
+      <div class="col-12 col-lg-6">
+        <div class="row no-gutters">
+          <div class="col-12 col-md-6 col-lg-12">
             <div class="deals-box-right">
               <img
                 class="deals-photo right-up"
@@ -27,9 +27,8 @@
               </div>
             </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="col-lg-12">
+
+          <div class="col-12 col-md-6 col-lg-12">
             <div class="deals-box-right">
               <img
                 class="deals-photo right-down"

--- a/src/sass/components/_section-deals.scss
+++ b/src/sass/components/_section-deals.scss
@@ -29,8 +29,9 @@
       height: 85%;
       background-color: rgba($text-color-black, 0.3);
       position: absolute;
-      top: 30px;
-      left: 43px;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
       color: $text-color-white;
       padding-left: 20px;
 
@@ -62,6 +63,8 @@
   }
 
   .deals-box-right {
+    position: relative;
+
     .right-up {
       width: 100%;
       height: 190px;
@@ -73,66 +76,79 @@
       width: 100%;
       height: 190px;
       border: 1px solid #e1e1e1;
-      margin-top: 20px;
       object-fit: cover;
+      margin-top: 20px;
     }
 
     .deals-discount2 {
       width: 100%;
-      height: 100%;
       background-color: rgba($text-color-white, 0.3);
       position: absolute;
-      top: 0;
-      left: 5px;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
 
       .deals-discount2-line1 {
+        margin: 0.5rem 0;
         font-size: 2.2rem;
         font-weight: 600;
-        position: relative;
-        top: 40px;
-        left: 30%;
         color: $text-color-black;
       }
 
       .deals-discount2-line2 {
         font-size: 1.5rem;
-        position: relative;
-        top: 30px;
-        left: 30%;
+        margin-right: 45px;
       }
 
       .deals-discount2-line3 {
         font-size: 2.35rem;
         font-weight: 600;
-        position: relative;
-        top: 20px;
-        left: 30%;
         color: $primary;
+        margin-right: 45px;
       }
     }
 
     .deals-discount3 {
       width: 100%;
-      height: 100%;
+      height: auto;
       background-color: rgba($text-color-white, 0.3);
       position: absolute;
-      top: 0px;
-      left: 0;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      justify-content: center;
 
       .deals-discount3-line1 {
         font-size: 1.6rem;
         font-weight: 600;
-        position: relative;
-        top: 90px;
-        left: 260px;
         color: $primary;
+        margin: 0 10px 0 0;
       }
 
       .deals-discount3-line2 {
         font-size: 1.2rem;
-        position: relative;
-        top: 80px;
-        left: 280px;
+        margin: 0 10px 0 0;
+      }
+    }
+  }
+}
+
+@media (max-width: 992px) {
+  .section-deals {
+    .deals-box-right {
+      .deals-discount2 {
+        top: calc(50% + 0.5rem);
+      }
+
+      .right-up {
+        margin-top: 20px;
       }
     }
   }


### PR DESCRIPTION
Zadaniem jest stworzenie wersji mobilnych sekcji "Promocje". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
Na szerokościach, gdzie trzy boxy nie mieszczą się obok siebie, należy ułożyć je jeden pod drugim (największy na górze, pod nim dwa mniejsze).

**Rozwiązanie:**
- delikatna zmiana struktury html (skasowanie jednego `row`) + responsywne klasy bootstrapa,
- poprawa pozycji absolutnych kontenerów z tekstami, w mniejszych banerach w css ->zmiana pozycji relatywnych linijek tekstu na flex,
- dwa marginesy w mediaqueries

**Pytanie:**
- na wszystkich tekstach było ustawione półprzezroczyste tło, tylko w masterze w banerach po prawej nie są tak widoczne, bo są na całe obrazek, poprawiać to ?

Link do [Jira](https://projects.kodilla.com/browse/WDP190601-58)